### PR TITLE
refactor: add editorconfig rules for md-files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,3 +9,7 @@ end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
+
+[*.md]
+max_line_length = off
+trim_trailing_whitespace = false


### PR DESCRIPTION
## Summary

If you set `trim_trailing_whitespace = true`, it will no longer be possible to start a new line with two blank lines in the markdown files.

## Basic example

Try it in `example.md`. I used vs code with [editorconfig plugin](https://marketplace.visualstudio.com/items?itemName=EditorConfig.EditorConfig).

## Motivation

Would be nice to have new lines. Added specific rules for md @h-enk .

## Checks

- [ x ] Read [Create a Pull Request](https://gethyas.com/docs/contributing/how-to-contribute/#create-a-pull-request)
- [ x ] Supports all screen sizes (if relevant)
- [ x ] Supports both light and dark mode (if relevant)
- [ x ] Passes `npm run test`
